### PR TITLE
Avoid namespace confusion

### DIFF
--- a/lib/shoulda/callback/matchers/rails_version_helper.rb
+++ b/lib/shoulda/callback/matchers/rails_version_helper.rb
@@ -23,17 +23,17 @@ module Shoulda
         
         def major_version_equals? number
           if active_record?
-            ActiveRecord::VERSION::MAJOR == number
+            ::ActiveRecord::VERSION::MAJOR == number
           else
-            ActiveModel::VERSION::MAJOR == number
+            ::ActiveModel::VERSION::MAJOR == number
           end
         end
         
         def minor_version_equals? number
           if active_record?
-            ActiveRecord::VERSION::MINOR == number
+            ::ActiveRecord::VERSION::MINOR == number
           else
-            ActiveModel::VERSION::MINOR == number
+            ::ActiveModel::VERSION::MINOR == number
           end
         end
         


### PR DESCRIPTION
Getting an error when running specs

```
NameError: uninitialized constant Shoulda::Callback::Matchers::ActiveModel::VERSION
```

Adding `::` fixes the issue.
