### PR TITLE
Add test-unit 3.0 for Rails 3.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -29,5 +29,4 @@ appraise 'rails 3.1' do
   gem 'rails', '~> 3.1.0'
   gem 'jquery-rails'
   gem 'sass-rails'
-  gem 'test-unit', '~> 3.0'
 end

--- a/Appraisals
+++ b/Appraisals
@@ -22,10 +22,12 @@ appraise 'rails 3.2' do
   gem 'rails', '~> 3.2.0'
   gem 'jquery-rails'
   gem 'sass-rails'
+  gem 'test-unit', '~> 3.0'
 end
 
 appraise 'rails 3.1' do
   gem 'rails', '~> 3.1.0'
   gem 'jquery-rails'
   gem 'sass-rails'
+  gem 'test-unit', '~> 3.0'
 end

--- a/gemfiles/rails_3.1.gemfile
+++ b/gemfiles/rails_3.1.gemfile
@@ -12,5 +12,6 @@ gem "psych", :platform=>:rbx
 gem "rails", "~> 3.1.0"
 gem "jquery-rails"
 gem "sass-rails"
+gem "test-unit", "~> 3.0"
 
 gemspec :path=>"../"

--- a/gemfiles/rails_3.1.gemfile
+++ b/gemfiles/rails_3.1.gemfile
@@ -12,6 +12,5 @@ gem "psych", :platform=>:rbx
 gem "rails", "~> 3.1.0"
 gem "jquery-rails"
 gem "sass-rails"
-gem "test-unit", "~> 3.0"
 
 gemspec :path=>"../"

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -12,5 +12,6 @@ gem "psych", :platform=>:rbx
 gem "rails", "~> 3.2.0"
 gem "jquery-rails"
 gem "sass-rails"
+gem "test-unit", "~> 3.0"
 
 gemspec :path=>"../"


### PR DESCRIPTION
Add `test-unit 3.0` gem to rails 3.2 as ruby 2.2+ no longer includes it in the core library.

This fixes an issue where none of the tests for Rails 3.2 would run.

Rails 3.1 shouldn't be affected since Ruby 2.2+ is not supported anyway.