### PR TITLE
Add `ostruct` dependency

### DIFF
--- a/shoulda-callback-matchers.gemspec
+++ b/shoulda-callback-matchers.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.extensions    = 'ext/mkrf_conf.rb'
 
   s.add_dependency('activesupport',           '>= 3')
+  s.add_dependency('ostruct', '~> 0.6.1')
 
   s.add_development_dependency('appraisal',   '~> 2.1.0')
   s.add_development_dependency('aruba')

--- a/shoulda-callback-matchers.gemspec
+++ b/shoulda-callback-matchers.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake',        '~> 10')
   s.add_development_dependency('rspec-rails', '~> 3')
 
+  s.required_ruby_version = ">= 2.5.0"
+
   if RUBY_ENGINE == 'rbx'
     s.add_development_dependency "rubysl", "~> 2"
     s.add_development_dependency "rubysl-test-unit", '~> 2'


### PR DESCRIPTION
### This PR resolves [this](https://github.com/jdliss/shoulda-callback-matchers/issues/32) issue.

- Add the `ostruct` gem as a runtime dependency to:
  - Support for Ruby version `3.5.0`.
  - Fix `/usr/share/rvm/rubies/ruby-3.4.1/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0` warnings when running `rspec` test suites for ruby version `3.4.1`.
- Since the `ostruct` gem requires the Ruby version to be `>= 2.5.0`, we have to set the `required_ruby_version` of this gem the same.